### PR TITLE
Add ability to exclude some aspects of schema and optionally add a border

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -83,6 +83,15 @@ Then you can use the +:namespace+ option to set the namespace to use:
 
   Sequel::Annotate.annotate(Dir['models/*.rb'], namespace: 'ModelNamespace')
 
+For PostgreSQL, you can optionally leave out indexes, foreign_keys, references,
+triggers, and constraints by passing in false as a parameter as follows:
+
+  Sequel::Annotate.annotate(Dir['models/*.rb'], foreign_keys: false, :indexes: false, constraints: false)
+
+The columns section can have a border on the top and bottom for easier visual distinction by setting the :border option to true
+
+  Sequel::Annotate.annotate(Dir['models/*.rb'], border: true)
+
 === Rake Task
 
 Here's an example rake task for sequel-annotate:

--- a/spec/sequel-annotate_spec.rb
+++ b/spec/sequel-annotate_spec.rb
@@ -107,6 +107,36 @@ describe Sequel::Annotate do
     Dir['spec/tmp/*.rb'].each{|f| File.delete(f)}
   end
 
+  it "#schema_info should not return sections we set to false" do
+    Sequel::Annotate.new(Item).schema_comment(indexes: false, constraints: false, foreign_keys: false, triggers: false).must_equal(fix_pg_comment((<<OUTPUT).chomp))
+# Table: items
+# Columns:
+#  id                    | integer               | PRIMARY KEY DEFAULT nextval('items_id_seq'::regclass)
+#  category_id           | integer               | NOT NULL
+#  manufacturer_name     | character varying(50) |
+#  manufacturer_location | text                  |
+#  in_stock              | boolean               | DEFAULT false
+#  name                  | text                  | DEFAULT 'John'::text
+#  price                 | double precision      | DEFAULT 0
+OUTPUT
+  end
+
+  it "#schema_info should return a border if we want one" do
+    Sequel::Annotate.new(Item).schema_comment(border: true, indexes: false, constraints: false, foreign_keys: false, triggers: false).must_equal(fix_pg_comment((<<OUTPUT).chomp))
+# Table: items
+# Columns:
+# ------------------------------------------------------------------------------------------------------
+#  id                    | integer               | PRIMARY KEY DEFAULT nextval('items_id_seq'::regclass)
+#  category_id           | integer               | NOT NULL
+#  manufacturer_name     | character varying(50) |
+#  manufacturer_location | text                  |
+#  in_stock              | boolean               | DEFAULT false
+#  name                  | text                  | DEFAULT 'John'::text
+#  price                 | double precision      | DEFAULT 0
+# ------------------------------------------------------------------------------------------------------
+OUTPUT
+  end
+
   it "#schema_info should return the model schema comment" do
     Sequel::Annotate.new(Item).schema_comment.must_equal(fix_pg_comment((<<OUTPUT).chomp))
 # Table: items


### PR DESCRIPTION
I'm upgrading a project from the older annotate-sequel gem to this version and to keep it closer to visual parity and reduce some unwanted noise, I added the ability to exclude indexes, references, etc from the annotation as well as put in an optional border on the top and bottom of the columns.