### PR TITLE
Finetune matching to allow for frozen_string_literal as first line of model files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Add support for rubocop-abiding `# frozen_string_literal: true` as the first line of model files (qortex) (#15)
+
 * Add support for PostgreSQL column comments (rgalanakis, jeremyevans) (#14)
 
 * Respect domain types on PostgreSQL (chanks) (#13)

--- a/spec/annotated_after/sitemwithcoding.rb
+++ b/spec/annotated_after/sitemwithcoding.rb
@@ -1,0 +1,20 @@
+# coding: xyz
+
+class SItemWithCoding < Sequel::Model(SDB[:items])
+end
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers

--- a/spec/annotated_after/sitemwithencoding.rb
+++ b/spec/annotated_after/sitemwithencoding.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+class SItemWithEncoding < Sequel::Model(SDB[:items])
+end
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers

--- a/spec/annotated_after/sitemwithfrozenliteral.rb
+++ b/spec/annotated_after/sitemwithfrozenliteral.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SItemWithFrozenLiteral < Sequel::Model(SDB[:items])
+end
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers

--- a/spec/annotated_after/sitemwithwarnindent.rb
+++ b/spec/annotated_after/sitemwithwarnindent.rb
@@ -1,0 +1,20 @@
+# warn_indent: true
+
+class SItemWithWarnIndent < Sequel::Model(SDB[:items])
+end
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers

--- a/spec/annotated_after/sitemwithwarnpastscope.rb
+++ b/spec/annotated_after/sitemwithwarnpastscope.rb
@@ -1,0 +1,21 @@
+# warn_past_scope: true
+# warn_indent: false
+# Additional comment that should stay
+class SItemWithWarnPastScope < Sequel::Model(SDB[:items])
+end
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers

--- a/spec/annotated_before/sitemwithcoding.rb
+++ b/spec/annotated_before/sitemwithcoding.rb
@@ -1,0 +1,20 @@
+# coding: xyz
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers
+
+class SItemWithCoding < Sequel::Model(SDB[:items])
+end

--- a/spec/annotated_before/sitemwithencoding.rb
+++ b/spec/annotated_before/sitemwithencoding.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers
+
+class SItemWithEncoding < Sequel::Model(SDB[:items])
+end

--- a/spec/annotated_before/sitemwithfrozenliteral.rb
+++ b/spec/annotated_before/sitemwithfrozenliteral.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers
+
+class SItemWithFrozenLiteral < Sequel::Model(SDB[:items])
+end

--- a/spec/annotated_before/sitemwithwarnindent.rb
+++ b/spec/annotated_before/sitemwithwarnindent.rb
@@ -1,0 +1,20 @@
+# warn_indent: true
+
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers
+
+class SItemWithWarnIndent < Sequel::Model(SDB[:items])
+end

--- a/spec/annotated_before/sitemwithwarnpastscope.rb
+++ b/spec/annotated_before/sitemwithwarnpastscope.rb
@@ -1,0 +1,21 @@
+# warn_past_scope: true
+# warn_indent: false
+# Table: items
+# Columns:
+#  id                    | integer          | PRIMARY KEY AUTOINCREMENT
+#  category_id           | integer          | NOT NULL
+#  manufacturer_name     | varchar(50)      |
+#  manufacturer_location | varchar(255)     |
+#  in_stock              | boolean          | DEFAULT 0
+#  name                  | varchar(255)     | DEFAULT 'John'
+#  price                 | double precision | DEFAULT 0
+# Indexes:
+#  manufacturer_name | (manufacturer_name)
+#  name              | UNIQUE (manufacturer_name, manufacturer_location)
+# Foreign key constraints:
+#  (category_id) REFERENCES categories
+#  (manufacturer_name, manufacturer_location) REFERENCES manufacturers
+
+# Additional comment that should stay
+class SItemWithWarnPastScope < Sequel::Model(SDB[:items])
+end

--- a/spec/sequel-annotate_spec.rb
+++ b/spec/sequel-annotate_spec.rb
@@ -97,6 +97,10 @@ class ::DomainTest < Sequel::Model; end
 class ::CommentTest < Sequel::Model; end
 class ::SItem < Sequel::Model(SDB[:items]); end
 class ::SItemWithFrozenLiteral < Sequel::Model(SDB[:items]); end
+class ::SItemWithCoding < Sequel::Model(SDB[:items]); end
+class ::SItemWithEncoding < Sequel::Model(SDB[:items]); end
+class ::SItemWithWarnIndent < Sequel::Model(SDB[:items]); end
+class ::SItemWithWarnPastScope < Sequel::Model(SDB[:items]); end
 class ::SCategory < Sequel::Model(SDB[:categories]); end
 class ::SManufacturer < Sequel::Model(SDB[:manufacturers]); end
 class ::NewlineTest < Sequel::Model; end
@@ -300,7 +304,7 @@ OUTPUT
     it "#annotate #{desc} should annotate the file comment" do
       FileUtils.cp(Dir['spec/unannotated/*.rb'], 'spec/tmp')
 
-      [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral].each do |model|
+      [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral, SItemWithCoding, SItemWithEncoding, SItemWithWarnIndent, SItemWithWarnPastScope].each do |model|
         filename = model.name.downcase
         2.times do
           Sequel::Annotate.new(model).annotate("spec/tmp/#{filename}.rb", *args)
@@ -316,7 +320,7 @@ OUTPUT
 
       2.times do
         Sequel::Annotate.annotate(Dir["spec/tmp/*.rb"], *args)
-        [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral].each do |model|
+        [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral, SItemWithCoding, SItemWithEncoding, SItemWithWarnIndent, SItemWithWarnPastScope].each do |model|
           filename = model.name.downcase
           expected = File.read("spec/annotated_#{pos}/#{filename}.rb")
           expected = fix_pg_comment(expected) if model.db == DB

--- a/spec/sequel-annotate_spec.rb
+++ b/spec/sequel-annotate_spec.rb
@@ -96,6 +96,7 @@ class ::Manufacturer < Sequel::Model; end
 class ::DomainTest < Sequel::Model; end
 class ::CommentTest < Sequel::Model; end
 class ::SItem < Sequel::Model(SDB[:items]); end
+class ::SItemWithFrozenLiteral < Sequel::Model(SDB[:items]); end
 class ::SCategory < Sequel::Model(SDB[:categories]); end
 class ::SManufacturer < Sequel::Model(SDB[:manufacturers]); end
 class ::NewlineTest < Sequel::Model; end
@@ -299,7 +300,7 @@ OUTPUT
     it "#annotate #{desc} should annotate the file comment" do
       FileUtils.cp(Dir['spec/unannotated/*.rb'], 'spec/tmp')
 
-      [Item, Category, Manufacturer, SItem, SCategory, SManufacturer].each do |model|
+      [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral].each do |model|
         filename = model.name.downcase
         2.times do
           Sequel::Annotate.new(model).annotate("spec/tmp/#{filename}.rb", *args)
@@ -315,7 +316,7 @@ OUTPUT
 
       2.times do
         Sequel::Annotate.annotate(Dir["spec/tmp/*.rb"], *args)
-        [Item, Category, Manufacturer, SItem, SCategory, SManufacturer].each do |model|
+        [Item, Category, Manufacturer, SItem, SCategory, SManufacturer, SItemWithFrozenLiteral].each do |model|
           filename = model.name.downcase
           expected = File.read("spec/annotated_#{pos}/#{filename}.rb")
           expected = fix_pg_comment(expected) if model.db == DB

--- a/spec/unannotated/sitemwithcoding.rb
+++ b/spec/unannotated/sitemwithcoding.rb
@@ -1,0 +1,4 @@
+# coding: xyz
+
+class SItemWithCoding < Sequel::Model(SDB[:items])
+end

--- a/spec/unannotated/sitemwithencoding.rb
+++ b/spec/unannotated/sitemwithencoding.rb
@@ -1,0 +1,4 @@
+# encoding: utf-8
+
+class SItemWithEncoding < Sequel::Model(SDB[:items])
+end

--- a/spec/unannotated/sitemwithfrozenliteral.rb
+++ b/spec/unannotated/sitemwithfrozenliteral.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SItemWithFrozenLiteral < Sequel::Model(SDB[:items])
+end

--- a/spec/unannotated/sitemwithwarnindent.rb
+++ b/spec/unannotated/sitemwithwarnindent.rb
@@ -1,0 +1,4 @@
+# warn_indent: true
+
+class SItemWithWarnIndent < Sequel::Model(SDB[:items])
+end

--- a/spec/unannotated/sitemwithwarnpastscope.rb
+++ b/spec/unannotated/sitemwithwarnpastscope.rb
@@ -1,0 +1,5 @@
+# warn_past_scope: true
+# warn_indent: false
+# Additional comment that should stay
+class SItemWithWarnPastScope < Sequel::Model(SDB[:items])
+end


### PR DESCRIPTION
Currently, `sequel-annotate` does not play nicely with `rubocop`-abiding `# frozen_string_literal: true` comment as the first line of a file, in `before` mode.

The comment is interpreted as user code, so the table is output again, leading to 2 tables being present in the file.

This PR fixes this, by gently leaving this comment in place if it's there.
It does not modify behaviour when the comment is not there.

New tests are included, previous tests pass ok.