### PR TITLE
Ignore files where self is reopened but not a model

### DIFF
--- a/lib/sequel/annotate.rb
+++ b/lib/sequel/annotate.rb
@@ -13,7 +13,7 @@ module Sequel
       namespace = options[:namespace]
 
       paths.each do |path|
-        if match = File.read(path).match(/class (\S+)\s*</)
+        if match = File.read(path).match(/class ([^\s<]+)\s*</)
           name = match[1]
           if namespace
             name = "#{namespace}::#{name}"

--- a/spec/unannotated/not_model.rb
+++ b/spec/unannotated/not_model.rb
@@ -1,0 +1,4 @@
+class NotModel
+  class << self
+  end
+end


### PR DESCRIPTION
Non-Sequel models files are normally safely ignored but if they re-open
the eigenclass then the matcher is incorrect.

Update the regular expression to only accept alphanumeric characters and the colon symbol.