### PR TITLE
Allow files to be skipped with a magic comment

### DIFF
--- a/lib/sequel/annotate.rb
+++ b/lib/sequel/annotate.rb
@@ -13,6 +13,8 @@ module Sequel
       namespace = options[:namespace]
 
       paths.each do |path|
+        next if File.read(path).match(/^#\s+sequel-annotate:\s+false$/i)
+
         if match = File.read(path).match(/class (\S+)\s*</)
           name = match[1]
           if namespace

--- a/spec/sequel-annotate_spec.rb
+++ b/spec/sequel-annotate_spec.rb
@@ -101,6 +101,7 @@ class ::SItemWithCoding < Sequel::Model(SDB[:items]); end
 class ::SItemWithEncoding < Sequel::Model(SDB[:items]); end
 class ::SItemWithWarnIndent < Sequel::Model(SDB[:items]); end
 class ::SItemWithWarnPastScope < Sequel::Model(SDB[:items]); end
+class ::SItemWithMagicComment < Sequel::Model(SDB[:items]); end
 class ::SCategory < Sequel::Model(SDB[:categories]); end
 class ::SManufacturer < Sequel::Model(SDB[:manufacturers]); end
 class ::NewlineTest < Sequel::Model; end
@@ -131,6 +132,12 @@ describe Sequel::Annotate do
   end
   after do
     Dir['spec/tmp/*.rb'].each{|f| File.delete(f)}
+  end
+
+  it "skips files with the sequel-annotate magic comment set to false" do
+    FileUtils.cp('spec/unannotated/sitemwithmagiccomment.rb', 'spec/tmp/')
+    Sequel::Annotate.annotate(['spec/tmp/sitemwithmagiccomment.rb'])
+    File.read('spec/tmp/sitemwithmagiccomment.rb').must_equal File.read('spec/unannotated/sitemwithmagiccomment.rb')
   end
 
   it "#schema_info should not return sections we set to false" do

--- a/spec/unannotated/sitemwithmagiccomment.rb
+++ b/spec/unannotated/sitemwithmagiccomment.rb
@@ -1,0 +1,4 @@
+# sequel-annotate: false
+
+class SItemWithMagicComment < Sequel::Model(SDB[:items])
+end


### PR DESCRIPTION
Using the `sequel-annotate` magic comment set to false, allow files to
be skipped the annotation process.

Example:

```ruby
# sequel-annotate: false

class Guest < User
end
```

Workaround for #17 
