### PR TITLE
Include lazy attributes

### DIFF
--- a/lib/sequel/annotate.rb
+++ b/lib/sequel/annotate.rb
@@ -6,7 +6,7 @@ module Sequel
     # Attempts to guess the model for each file using a regexp match of
     # the file's content, if this doesn't work, you'll need to create
     # an instance manually and pass in the model and path. Example:
-    # 
+    #
     #   Sequel::Annotate.annotate(Dir['models/*.rb'])
     def self.annotate(paths, options = {})
       Sequel.extension :inflector
@@ -80,7 +80,7 @@ module Sequel
       end
     end
 
-    # The schema comment to use for this model.  
+    # The schema comment to use for this model.
     # For all databases, includes columns, indexes, and foreign
     # key constraints in this table referencing other tables.
     # On PostgreSQL, also includes check constraints, triggers,
@@ -271,7 +271,10 @@ SQL
         {}
       end
 
-      rows = model.columns.map do |col|
+      show_hidden_columns = defined?(Sequel::Plugins::LazyAttributes) &&
+                            model.plugins.include?(Sequel::Plugins::LazyAttributes)
+      columns = show_hidden_columns ? model.select_all.columns : model.columns
+      rows = columns.map do |col|
         sch = model.db_schema[col]
         parts = [
           col.to_s,

--- a/spec/sequel-annotate_spec.rb
+++ b/spec/sequel-annotate_spec.rb
@@ -117,6 +117,9 @@ class ::Manufacturer < Sequel::Model; end
 class ::DomainTest < Sequel::Model; end
 class ::CommentTest < Sequel::Model; end
 class ::FkTest < Sequel::Model; end
+class ::LazyTest < Sequel::Model(:manufacturers)
+  plugin :lazy_attributes, :name
+end
 class ::SItem < Sequel::Model(SDB[:items]); end
 class ::SItemWithFrozenLiteral < Sequel::Model(SDB[:items]); end
 class ::SItemWithCoding < Sequel::Model(SDB[:items]); end
@@ -402,8 +405,20 @@ OUTPUT
 # Foreign key constraints:
 #  (c) REFERENCES fk_tests(b)
 OUTPUT
+
+    Sequel::Annotate.new(LazyTest).schema_comment.must_equal(fix_pg_comment((<<OUTPUT).chomp))
+# Table: manufacturers
+# Primary Key: (name, location)
+# Columns:
+#  name     | text |
+#  location | text |
+# Indexes:
+#  manufacturers_pkey | PRIMARY KEY btree (name, location)
+# Referenced By:
+#  items | items_manufacturer_name_fkey | (manufacturer_name, manufacturer_location) REFERENCES manufacturers(name, location)
+OUTPUT
   end
-  
+
   it "#annotate should append the schema comment if current schema comment is not at the end of the file" do
     FileUtils.cp('spec/unannotated/sitemwithcoding.rb', 'spec/tmp')
     Sequel::Annotate.new(SItemWithCoding).annotate("spec/tmp/sitemwithcoding.rb", :position=>:before)


### PR DESCRIPTION
If the `lazy_attributes` plugin is loaded,
re-select all columns from the database.
Otherwise they are not included in `model.columns` or the schema info output.

See https://github.com/jeremyevans/sequel-annotate/discussions/24